### PR TITLE
Updated url match pattern

### DIFF
--- a/mySC.js
+++ b/mySC.js
@@ -40,7 +40,7 @@ $(document).ready(function() {
   // New SoundCloud URL requested via prompt()
   $("#newSong").click(function() {
     var url = prompt("Enter in a new SoundCloud URL:");
-    var scMatch = url.match(/^https:\/\/soundcloud\.com\/[a-z1-9\/-]*/);
+    var scMatch = url.match(/^https:\/\/soundcloud\.com\/[a-z1-9-]*\/[a-z1-9-]*\/?$/);
     if(url !== null && scMatch !== null){
       playSC(url, true);
       getSCinfo(url);


### PR DESCRIPTION
I've made a SoundCloud Web Player [for myself](https://github.com/R3l4x3/soundcloud-webplayer) to learn Vue.js.

I've seen that your url match pattern was not quite accurate and invalid URLs were possible.

I think with this pattern only valid URLs are possible.